### PR TITLE
Fix code closing tag

### DIFF
--- a/gbabiosdump/index.html
+++ b/gbabiosdump/index.html
@@ -320,7 +320,7 @@ Hello, in this guide, I will show you how to dump a GBA bios</p>
 </li>
 <br/>
 <li>
-  <p> Open_AGB_firm users: the savefile is in the <code>SD:/3ds/open_agb_firm/saves<code> folder.</p>
+  <p> Open_AGB_firm users: the savefile is in the <code>SD:/3ds/open_agb_firm/saves</code> folder.</p>
 <p>Either drag &amp; drop the .sav file onto the <code>Bios_Shrinker.py</code> file or run it with python3, this will output a file called <code>bios.bin</code> which is the correct bios.</p>
 <br/>
 <p><strong>Here are the hashes of a clean bios on GBA</strong><br/>


### PR DESCRIPTION
The rest of the page was getting treated like it's wrapped in a double `<code>`  tag